### PR TITLE
fix bad output windows user experiencing.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strings"
 )
 
 func main() {
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("Enter username: ")
 	username, _ := reader.ReadString('\n')
-	username = username[:len(username)-1]  // Trim the newline character
+	username = strings.TrimSpace(username) // Trim the newline character
 
 	suggestions := suggestEmails(username)
 


### PR DESCRIPTION
Window users will get wrong output using the program due to windows using two characters the CR LF sequence to mark a line break.

Using the strings package TrimSpace() function will fix the issue, which I just did.
